### PR TITLE
Old gcc hash specialization fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ compiler:
 os:
 - linux
 
-before_install:
+#before_install:
   # C++14
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
+  #  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  #- sudo apt-get update -qq
 
-install: 
+#install: 
   # C++14
-  - sudo apt-get install -qq g++-6
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
+  #- sudo apt-get install -qq g++-6
+  #- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 90
   
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ BINDIR = bin
 LIBDIR = lib
 
 MKDIR = mkdir -p
-CXX = g++
+CXX = g++-4.9
 CFLAGS = -std=c++11 -g -I/usr/local/include/PCSC -I/usr/include/PCSC
 LDFLAGS = -L/usr/local/lib -lpcsclite
 ifeq ($(PLATFORM),posix)
 	LDFLAGS += -lpthread
 endif
 
-export BINDIR LIBDIR CFLAGS LDFLAGS LIBNAME MAJOR_VERSION MINOR_VERSION PATCHLEVEL PLATFORM
+export CXX BINDIR LIBDIR CFLAGS LDFLAGS LIBNAME MAJOR_VERSION MINOR_VERSION PATCHLEVEL PLATFORM
 
 all:
 	$(MKDIR) $(LIBDIR) $(BINDIR)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BINDIR = bin
 LIBDIR = lib
 
 MKDIR = mkdir -p
-CXX = g++-4.9
+CXX = g++
 CFLAGS = -std=c++11 -g -I/usr/local/include/PCSC -I/usr/include/PCSC
 LDFLAGS = -L/usr/local/lib -lpcsclite
 ifeq ($(PLATFORM),posix)

--- a/src/nis.cpp
+++ b/src/nis.cpp
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include <vector>
+#include <functional>
 #include <cstring>
 #include <algorithm>
 #include "reader.h"
@@ -26,7 +27,7 @@ public:
 	}
 private:
 	NISManager() {}
-	unordered_map<BackendType,Reader*> backends;
+	unordered_map<BackendType,Reader*,std::hash<int>> backends;
 	vector<string> readers;
 	char *idList;
 public:
@@ -42,7 +43,7 @@ public:
 		} 
 		return backend; 
 	}
-	const unordered_map<BackendType,Reader*> &getBackends() { return backends; };
+	const unordered_map<BackendType,Reader*,std::hash<int>> &getBackends() { return backends; };
 	vector<string> &getReaders() { return readers; }
 	char* getIdentifiersList() { return idList; }
 	void deleteIdentifiersList() { if(idList) delete[] idList; }


### PR DESCRIPTION
- added a template parameter to treat enum used as keys to unordered_map as int (no need for a real specialization here)